### PR TITLE
Upgrade ffi for Node 10 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Node library to read data from Omron D6T thermal sensors",
   "main": "d6t.js",
   "dependencies": {
-    "ffi": "~2.2.0",
+    "ffi": "~2.3.0",
     "ref": "^1.3.5"
   },
   "devDependencies": {},


### PR DESCRIPTION
Installing the d6t library on Node 10 currently leads to build failures in the ffi module. These have been fixed in the current version of that dependency (2.3.0). This MR simply updates your package.json, would be great if you could also make a new minor release on npm. :)